### PR TITLE
Add step-by-step mode with pause and navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,6 +64,15 @@
                     <button id="resetBtn" class="glow-button bg-red-600 hover:bg-red-700 text-white px-6 py-3 rounded-lg font-semibold transition-all">
                         <i class="fas fa-refresh mr-2"></i>Reset
                     </button>
+                    <button id="pauseBtn" class="glow-button bg-yellow-600 hover:bg-yellow-700 text-white px-6 py-3 rounded-lg font-semibold transition-all">
+                        <i class="fas fa-pause mr-2"></i>Pause
+                    </button>
+                    <button id="nextStepBtn" class="glow-button bg-blue-600 hover:bg-blue-700 text-white px-6 py-3 rounded-lg font-semibold transition-all">
+                        <i class="fas fa-step-forward mr-2"></i>Next Step
+                    </button>
+                    <button id="prevStepBtn" class="glow-button bg-blue-600 hover:bg-blue-700 text-white px-6 py-3 rounded-lg font-semibold transition-all">
+                        <i class="fas fa-step-backward mr-2"></i>Previous Step
+                    </button>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
## Summary
- add Pause, Next Step and Previous Step buttons
- implement step-by-step logic in `script.js`
- record array snapshots to allow stepping back

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_68402461d39883218b7e9b7634256e74