### PR TITLE
Add pseudocode visualization

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,9 +77,10 @@
             </div>
         </section>
 
-        <section class="glass-effect rounded-2xl p-8 mb-12" id="visualization">
-            <div class="flex justify-between items-center mb-6">
-                <h2 class="text-2xl font-bold">Visualization</h2>
+        <section class="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-12">
+            <div class="glass-effect rounded-2xl p-8" id="visualization">
+                <div class="flex justify-between items-center mb-6">
+                    <h2 class="text-2xl font-bold">Visualization</h2>
                 <div class="flex gap-4 text-sm">
                     <div class="flex items-center">
                         <div class="w-4 h-4 bg-gradient-to-r from-blue-500 to-purple-600 rounded mr-2"></div>
@@ -99,7 +100,15 @@
                     </div>
                 </div>
             </div>
-            <div id="arrayContainer" class="h-96 border-2 border-gray-700 rounded-lg p-4 bg-gray-800 flex items-end justify-center overflow-hidden"></div>
+                <div id="arrayContainer" class="h-96 border-2 border-gray-700 rounded-lg p-4 bg-gray-800 flex items-end justify-center overflow-hidden"></div>
+            </div>
+            <div class="glass-effect rounded-2xl p-8" id="pseudocodeContainer">
+                <h3 class="text-2xl font-bold mb-6">
+                    <i class="fas fa-code mr-2"></i>
+                    Pseudocode
+                </h3>
+                <pre id="pseudocode" class="bg-gray-800 p-4 rounded-lg text-sm whitespace-pre-wrap"></pre>
+            </div>
         </section>
 
         <section class="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-12">

--- a/script.js
+++ b/script.js
@@ -53,11 +53,57 @@
                         worstComplexity: 'O(n log n)'
                     }
                 };
+
+                this.pseudocodes = {
+                    bubble: [
+                        'for i from 0 to n-1',
+                        '  for j from 0 to n-i-1',
+                        '    if A[j] > A[j+1]',
+                        '      swap A[j], A[j+1]',
+                        '  mark n-i-1 as sorted'
+                    ],
+                    selection: [
+                        'for i from 0 to n-1',
+                        '  minIndex = i',
+                        '  for j from i+1 to n-1',
+                        '    if A[j] < A[minIndex]',
+                        '      minIndex = j',
+                        '  swap A[i], A[minIndex]'
+                    ],
+                    insertion: [
+                        'for i from 1 to n-1',
+                        '  key = A[i]',
+                        '  j = i - 1',
+                        '  while j >= 0 and A[j] > key',
+                        '    A[j+1] = A[j]; j--',
+                        '  A[j+1] = key'
+                    ],
+                    merge: [
+                        'if left >= right return',
+                        'mid = (left + right) / 2',
+                        'mergeSort(left, mid)',
+                        'mergeSort(mid+1, right)',
+                        'merge(left, mid, right)'
+                    ],
+                    quick: [
+                        'if low < high',
+                        '  pi = partition(low, high)',
+                        '  quickSort(low, pi-1)',
+                        '  quickSort(pi+1, high)'
+                    ],
+                    heap: [
+                        'buildMaxHeap()',
+                        'for i from n-1 downto 1',
+                        '  swap A[0], A[i]',
+                        '  heapify(0, i)'
+                    ]
+                };
                 this.initializeEventListeners();
                 this.generateArray(); // Generate initial array
                 this.updateAlgorithmInfo(); // Set initial algorithm info
                 this.initializeAnimations();
                 this.createComplexityChart();
+                this.displayPseudocode();
             }
 
             initializeEventListeners() {
@@ -189,19 +235,24 @@
             async bubbleSort() {
                 const n = this.array.length;
                 for (let i = 0; i < n - 1; i++) {
+                    this.highlightPseudo(0);
                     for (let j = 0; j < n - i - 1; j++) {
+                        this.highlightPseudo(1);
                         if (!this.isRunning) return;
 
                         await this.highlightBars([j, j + 1], 'bar-comparing', this.speed);
                         this.updateStats('comparisons');
-
+                        this.highlightPseudo(2);
                         if (this.array[j] > this.array[j + 1]) {
+                            this.highlightPseudo(3);
                             await this.swapBars(j, j + 1);
                         }
                     }
+                    this.highlightPseudo(4);
                     await this.highlightBars([n - i - 1], 'bar-sorted', 100); // Mark as sorted
                 }
                 if (n > 0) await this.highlightBars([0], 'bar-sorted', 100); // Mark the last element if exists
+                this.clearPseudoHighlight();
             }
 
             async selectionSort() {
@@ -209,22 +260,30 @@
                 for (let i = 0; i < n - 1; i++) {
                     if (!this.isRunning) return;
 
+                    this.highlightPseudo(0);
+
                     let minIdx = i;
+                    this.highlightPseudo(1);
                     for (let j = i + 1; j < n; j++) {
+                        this.highlightPseudo(2);
                         await this.highlightBars([j, minIdx], 'bar-comparing', this.speed);
                         this.updateStats('comparisons');
 
+                        this.highlightPseudo(3);
                         if (this.array[j] < this.array[minIdx]) {
+                            this.highlightPseudo(4);
                             minIdx = j;
                         }
                     }
 
                     if (minIdx !== i) {
+                        this.highlightPseudo(5);
                         await this.swapBars(i, minIdx);
                     }
                     await this.highlightBars([i], 'bar-sorted', 100);
                 }
                 if (n > 0) await this.highlightBars([n - 1], 'bar-sorted', 100);
+                this.clearPseudoHighlight();
             }
 
             async insertionSort() {
@@ -234,14 +293,20 @@
                 for (let i = 1; i < n; i++) {
                     if (!this.isRunning) return;
 
+                    this.highlightPseudo(0);
+
                     let key = this.array[i];
+                    this.highlightPseudo(1);
                     let j = i - 1;
+                    this.highlightPseudo(2);
 
                     // Highlight the element being inserted
                     await this.highlightBars([i], 'bar-comparing', this.speed);
 
                     while (j >= 0 && this.array[j] > key) {
                         if (!this.isRunning) return;
+
+                        this.highlightPseudo(3);
 
                         await this.highlightBars([j, j + 1], 'bar-comparing', this.speed);
                         this.updateStats('comparisons');
@@ -256,9 +321,11 @@
 
                         j--;
                         this.updateStats('swaps'); // This is more of a shift
+                        this.highlightPseudo(4);
                     }
 
                     this.array[j + 1] = key;
+                    this.highlightPseudo(5);
                     const bars = document.querySelectorAll('.bar');
                     if (bars[j + 1]) {
                         bars[j + 1].style.height = `${key}px`;
@@ -271,6 +338,7 @@
                         await this.highlightBars([k], 'bar-sorted', 50);
                     }
                 }
+                this.clearPseudoHighlight();
             }
 
             async mergeSort(left = 0, right = this.array.length - 1) {
@@ -636,6 +704,31 @@
                 document.getElementById('avgComplexity').textContent = info.avgComplexity;
                 document.getElementById('bestComplexity').textContent = info.bestComplexity;
                 document.getElementById('worstComplexity').textContent = info.worstComplexity;
+                this.displayPseudocode();
+            }
+
+            displayPseudocode() {
+                const algorithm = document.getElementById('algorithmSelect').value;
+                const codeLines = this.pseudocodes[algorithm] || [];
+                const container = document.getElementById('pseudocode');
+                if (!container) return;
+                container.innerHTML = codeLines.map(line => `<span class="pseudocode-line">${line}</span>`).join('\n');
+            }
+
+            highlightPseudo(index) {
+                const lines = document.querySelectorAll('#pseudocode .pseudocode-line');
+                lines.forEach((el, i) => {
+                    if (i === index) {
+                        el.classList.add('highlight');
+                    } else {
+                        el.classList.remove('highlight');
+                    }
+                });
+            }
+
+            clearPseudoHighlight() {
+                const lines = document.querySelectorAll('#pseudocode .pseudocode-line');
+                lines.forEach(el => el.classList.remove('highlight'));
             }
 
             createComplexityChart() {

--- a/style.css
+++ b/style.css
@@ -81,3 +81,18 @@
         .complexity-chart {
             height: 300px;
         }
+
+        #pseudocodeContainer {
+            max-height: 400px;
+            overflow-y: auto;
+        }
+
+        .pseudocode-line {
+            display: block;
+            padding: 2px 4px;
+            border-radius: 4px;
+        }
+
+        .pseudocode-line.highlight {
+            background: rgba(255, 255, 255, 0.2);
+        }


### PR DESCRIPTION
## Summary
- show pseudocode next to the visualization panel
- add highlight styles and code
- include pseudocode data for all algorithms
- sync bubble, selection and insertion sort with pseudocode highlighting

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_684026078068832185489446ddaecb35